### PR TITLE
form api 자동배포 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,13 +1,13 @@
 name: deploy
 on:
-  push:
-    branches:
-      - main
-  # 아래는 PR 올라온 환경에서 동작하는지 확인하는 용도 추후에 삭제하기 !!
-#  pull_request:
+#  push:
 #    branches:
 #      - main
-#      - dev
+  # 아래는 PR 올라온 환경에서 동작하는지 확인하는 용도 추후에 삭제하기 !!
+  pull_request:
+    branches:
+      - main
+      - dev
 
 jobs:
   prod_CICD:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,21 +66,21 @@ jobs:
 
       - name: Build docker image and push docker images to ecr (api)
         run: |
-          docker build -t ai-news-noti-bot-real-api -f DockerfileApi .
-          docker tag ai-news-noti-bot-real-api:latest ${{ secrets.AWS_REGISTRY_URL }}/ai-news-noti-bot-real-api:latest
-            docker push ${{ secrets.AWS_REGISTRY_URL }}/ai-news-noti-bot-real-api:latest
+          docker build -t ai-news-noti-bot-api-real -f DockerfileApi .
+          docker tag ai-news-noti-bot-api-real:latest ${{ secrets.AWS_REGISTRY_URL }}/ai-news-noti-bot-api-real:latest
+            docker push ${{ secrets.AWS_REGISTRY_URL }}/ai-news-noti-bot-api-real:latest
 
       - name: Update lambda function (api)
-        run: aws lambda update-function-code --function-name ai-news-noti-bot-api --image-uri ${{ secrets.AWS_REGISTRY_URL }}/ai-news-noti-bot-real-api:latest
+        run: aws lambda update-function-code --function-name ai-news-noti-bot-api --image-uri ${{ secrets.AWS_REGISTRY_URL }}/ai-news-noti-bot-api-real:latest
 
       - name: Delete untagged images in ECR (api)
         run: |
           # Get untagged image digest
-          UNTAGGED_IMAGES=$(aws ecr describe-images --repository-name ai-news-noti-bot-real-api --query 'imageDetails[?imageTags==null].imageDigest' --output json)
+          UNTAGGED_IMAGES=$(aws ecr describe-images --repository-name ai-news-noti-bot-api-real --query 'imageDetails[?imageTags==null].imageDigest' --output json)
           
           # Delete untagged images
           if [ -n "$UNTAGGED_IMAGES" ]; then
             for IMAGE_DIGEST in $(echo "$UNTAGGED_IMAGES" | jq -r '.[]'); do
-              aws ecr batch-delete-image --repository-name ai-news-noti-bot-real-api --image-ids imageDigest=$IMAGE_DIGEST
+              aws ecr batch-delete-image --repository-name ai-news-noti-bot-api-real --image-ids imageDigest=$IMAGE_DIGEST
             done
           fi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,7 +71,7 @@ jobs:
             docker push ${{ secrets.AWS_REGISTRY_URL }}/ai-news-noti-bot-api-real:latest
 
       - name: Update lambda function (api)
-        run: aws lambda update-function-code --function-name ai-news-noti-bot-api --image-uri ${{ secrets.AWS_REGISTRY_URL }}/ai-news-noti-bot-api-real:latest
+        run: aws lambda update-function-code --function-name ai-news-noti-bot-api-real --image-uri ${{ secrets.AWS_REGISTRY_URL }}/ai-news-noti-bot-api-real:latest
 
       - name: Delete untagged images in ECR (api)
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Build docker image and push docker images to ecr (api)
         run: |
-          docker build -t ai-news-noti-bot-real-api -f DockefileApi .
+          docker build -t ai-news-noti-bot-real-api -f DockerfileApi .
           docker tag ai-news-noti-bot-real-api:latest ${{ secrets.AWS_REGISTRY_URL }}/ai-news-noti-bot-real-api:latest
             docker push ${{ secrets.AWS_REGISTRY_URL }}/ai-news-noti-bot-real-api:latest
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,26 +43,26 @@ jobs:
       - name: AWS ECR login
         run: aws ecr get-login-password --region ${{ secrets.AWS_REGION }} | docker login --username AWS --password-stdin ${{ secrets.AWS_REGISTRY_URL }}
 
-#      - name: Build docker image and push docker images to ecr
-#        run: |
-#          docker build -t ai-news-noti-bot-real .
-#          docker tag ai-news-noti-bot-real:latest ${{ secrets.AWS_REGISTRY_URL }}/ai-news-noti-bot-real:latest
-#          docker push ${{ secrets.AWS_REGISTRY_URL }}/ai-news-noti-bot-real:latest
-#
-#      - name: Update lambda function
-#        run: aws lambda update-function-code --function-name ai-news-noti-bot-real --image-uri ${{ secrets.AWS_REGISTRY_URL }}/ai-news-noti-bot-real:latest
-#
-#      - name: Delete untagged images in ECR
-#        run: |
-#          # Get untagged image digest
-#          UNTAGGED_IMAGES=$(aws ecr describe-images --repository-name ai-news-noti-bot-real --query 'imageDetails[?imageTags==null].imageDigest' --output json)
-#
-#          # Delete untagged images
-#          if [ -n "$UNTAGGED_IMAGES" ]; then
-#            for IMAGE_DIGEST in $(echo "$UNTAGGED_IMAGES" | jq -r '.[]'); do
-#              aws ecr batch-delete-image --repository-name ai-news-noti-bot-real --image-ids imageDigest=$IMAGE_DIGEST
-#            done
-#          fi
+      - name: Build docker image and push docker images to ecr
+        run: |
+          docker build -t ai-news-noti-bot-real .
+          docker tag ai-news-noti-bot-real:latest ${{ secrets.AWS_REGISTRY_URL }}/ai-news-noti-bot-real:latest
+          docker push ${{ secrets.AWS_REGISTRY_URL }}/ai-news-noti-bot-real:latest
+
+      - name: Update lambda function
+        run: aws lambda update-function-code --function-name ai-news-noti-bot-real --image-uri ${{ secrets.AWS_REGISTRY_URL }}/ai-news-noti-bot-real:latest
+
+      - name: Delete untagged images in ECR
+        run: |
+          # Get untagged image digest
+          UNTAGGED_IMAGES=$(aws ecr describe-images --repository-name ai-news-noti-bot-real --query 'imageDetails[?imageTags==null].imageDigest' --output json)
+
+          # Delete untagged images
+          if [ -n "$UNTAGGED_IMAGES" ]; then
+            for IMAGE_DIGEST in $(echo "$UNTAGGED_IMAGES" | jq -r '.[]'); do
+              aws ecr batch-delete-image --repository-name ai-news-noti-bot-real --image-ids imageDigest=$IMAGE_DIGEST
+            done
+          fi
 
       - name: Build docker image and push docker images to ecr (api)
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,13 +1,13 @@
 name: deploy
 on:
-  push:
-    branches:
-      - main
-  # 아래는 PR 올라온 환경에서 동작하는지 확인하는 용도 추후에 삭제하기 !!
-#  pull_request:
+#  push:
 #    branches:
 #      - main
-#      - dev
+  # 아래는 PR 올라온 환경에서 동작하는지 확인하는 용도 추후에 삭제하기 !!
+  pull_request:
+    branches:
+      - main
+      - dev
 
 jobs:
   prod_CICD:
@@ -43,23 +43,44 @@ jobs:
       - name: AWS ECR login
         run: aws ecr get-login-password --region ${{ secrets.AWS_REGION }} | docker login --username AWS --password-stdin ${{ secrets.AWS_REGISTRY_URL }}
 
-      - name: Build docker image and push docker images to ecr
+#      - name: Build docker image and push docker images to ecr
+#        run: |
+#          docker build -t ai-news-noti-bot-real .
+#          docker tag ai-news-noti-bot-real:latest ${{ secrets.AWS_REGISTRY_URL }}/ai-news-noti-bot-real:latest
+#          docker push ${{ secrets.AWS_REGISTRY_URL }}/ai-news-noti-bot-real:latest
+#
+#      - name: Update lambda function
+#        run: aws lambda update-function-code --function-name ai-news-noti-bot-real --image-uri ${{ secrets.AWS_REGISTRY_URL }}/ai-news-noti-bot-real:latest
+#
+#      - name: Delete untagged images in ECR
+#        run: |
+#          # Get untagged image digest
+#          UNTAGGED_IMAGES=$(aws ecr describe-images --repository-name ai-news-noti-bot-real --query 'imageDetails[?imageTags==null].imageDigest' --output json)
+#
+#          # Delete untagged images
+#          if [ -n "$UNTAGGED_IMAGES" ]; then
+#            for IMAGE_DIGEST in $(echo "$UNTAGGED_IMAGES" | jq -r '.[]'); do
+#              aws ecr batch-delete-image --repository-name ai-news-noti-bot-real --image-ids imageDigest=$IMAGE_DIGEST
+#            done
+#          fi
+
+      - name: Build docker image and push docker images to ecr (api)
         run: |
-          docker build -t ai-news-noti-bot-real .
-          docker tag ai-news-noti-bot-real:latest ${{ secrets.AWS_REGISTRY_URL }}/ai-news-noti-bot-real:latest
-          docker push ${{ secrets.AWS_REGISTRY_URL }}/ai-news-noti-bot-real:latest
+          docker build -t ai-news-noti-bot-real-api -f DockefileApi .
+          docker tag ai-news-noti-bot-real-api:latest ${{ secrets.AWS_REGISTRY_URL }}/ai-news-noti-bot-real-api:latest
+            docker push ${{ secrets.AWS_REGISTRY_URL }}/ai-news-noti-bot-real-api:latest
 
-      - name: Update lambda function
-        run: aws lambda update-function-code --function-name ai-news-noti-bot-real --image-uri ${{ secrets.AWS_REGISTRY_URL }}/ai-news-noti-bot-real:latest
+      - name: Update lambda function (api)
+        run: aws lambda update-function-code --function-name ai-news-noti-bot-api --image-uri ${{ secrets.AWS_REGISTRY_URL }}/ai-news-noti-bot-real-api:latest
 
-      - name: Delete untagged images in ECR
+      - name: Delete untagged images in ECR (api)
         run: |
           # Get untagged image digest
-          UNTAGGED_IMAGES=$(aws ecr describe-images --repository-name ai-news-noti-bot-real --query 'imageDetails[?imageTags==null].imageDigest' --output json)
+          UNTAGGED_IMAGES=$(aws ecr describe-images --repository-name ai-news-noti-bot-real-api --query 'imageDetails[?imageTags==null].imageDigest' --output json)
           
           # Delete untagged images
           if [ -n "$UNTAGGED_IMAGES" ]; then
             for IMAGE_DIGEST in $(echo "$UNTAGGED_IMAGES" | jq -r '.[]'); do
-              aws ecr batch-delete-image --repository-name ai-news-noti-bot-real --image-ids imageDigest=$IMAGE_DIGEST
+              aws ecr batch-delete-image --repository-name ai-news-noti-bot-real-api --image-ids imageDigest=$IMAGE_DIGEST
             done
           fi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,13 +1,13 @@
 name: deploy
 on:
-#  push:
-#    branches:
-#      - main
-  # 아래는 PR 올라온 환경에서 동작하는지 확인하는 용도 추후에 삭제하기 !!
-  pull_request:
+  push:
     branches:
       - main
-      - dev
+  # 아래는 PR 올라온 환경에서 동작하는지 확인하는 용도 추후에 삭제하기 !!
+#  pull_request:
+#    branches:
+#      - main
+#      - dev
 
 jobs:
   prod_CICD:

--- a/DockerfileApi
+++ b/DockerfileApi
@@ -23,7 +23,9 @@ RUN pnpm build \
     && cp ../../common/package.json ./dist/common \
     && cd ./dist \
     && pnpm install \
-    && cp ../../../common/.env ./common/.env
+    && cp ../../../common/.env ./common/.env \
+    && echo "import { handler as test } from './lambdas/register-site-api/src/index.js'" > index.mjs \
+    && echo "export const handler = test;" >> index.mjs
 
 WORKDIR ${LAMBDA_TASK_ROOT}
 

--- a/DockerfileApi
+++ b/DockerfileApi
@@ -1,0 +1,32 @@
+# AWS Lambda의 Node.js 18 베이스 이미지 사용
+FROM public.ecr.aws/lambda/nodejs:18
+
+# pnpm 설치
+RUN npm install -g typescript
+RUN npm install -g pnpm
+
+# 전체 파일 복사
+COPY . ${LAMBDA_TASK_ROOT}
+
+# 디렉터리 위치 이동
+WORKDIR ${LAMBDA_TASK_ROOT}
+
+RUN pnpm install
+
+# 의존성 설치를 위한 작업 디렉토리로 변경
+WORKDIR ./lambdas/register-site-api
+
+# 실행 환경 구성
+RUN pnpm build \
+    && cp ../../pnpm-workspace.yaml ./dist \
+    && cp ./package.json ./dist/lambdas/register-site-api \
+    && cp ../../common/package.json ./dist/common \
+    && cd ./dist \
+    && pnpm install \
+    && cp ../../../common/.env ./common/.env \
+    && echo "import { handler as test } from './lambdas/register-site-api/src/index.js'" > index.mjs \
+    && echo "export const handler = test;" >> index.mjs
+
+WORKDIR ${LAMBDA_TASK_ROOT}
+
+CMD ["lambdas/register-site-api/dist/index.handler"]

--- a/DockerfileApi
+++ b/DockerfileApi
@@ -23,7 +23,7 @@ RUN pnpm build \
     && cp ../../common/package.json ./dist/common \
     && cd ./dist \
     && pnpm install \
-    && cp ../../../common/.env ./common/.env \
+    && cp ../../../common/.env ./common/.env
 
 WORKDIR ${LAMBDA_TASK_ROOT}
 

--- a/DockerfileApi
+++ b/DockerfileApi
@@ -24,8 +24,6 @@ RUN pnpm build \
     && cd ./dist \
     && pnpm install \
     && cp ../../../common/.env ./common/.env \
-    && echo "import { handler as test } from './lambdas/register-site-api/src/index.js'" > index.mjs \
-    && echo "export const handler = test;" >> index.mjs
 
 WORKDIR ${LAMBDA_TASK_ROOT}
 

--- a/pages/postSiteForm/index.html
+++ b/pages/postSiteForm/index.html
@@ -73,13 +73,13 @@
 
           <div class="formbold-input-flex">
             <div style="width: 100%">
-              <label for="requestBy" class="formbold-form-label">
+              <label for="requestedBy" class="formbold-form-label">
                 제출자
               </label>
               <input
                 type="text"
-                name="requestBy"
-                id="requestBy"
+                name="requestedBy"
+                id="requestedBy"
                 placeholder="justin.dev"
                 class="formbold-form-input"
               />


### PR DESCRIPTION
Close #28 

## Done
- github action에 form api 람다 배포 스크립트 추가
- form api용 Dockerfile인 `DockerfileApi` 추가
- html form의 label과 db schema key 동일하게 수정
- html 페이지에서 제출 시 실제 동작 테스트

## To Reviewer
- 기존에 `deploy.yml` 잘 짜여져있어서 별 어려움 없이 추가할 수 있었습니다. 👍
- api용 Dockerfile을 `DockerfileApi`로 추가했습니다.
- 이제 정말 기능 구현은 다 끝난 것 같네요
- 처음에 멀티모듈로 구성하면서 생각했던건데요, 추후에 프로젝트 고도화하게되면 각 프로젝트 안에 `Dockerfile`을 넣고, github action은 각 프로젝트마다 병렬로 처리하도록 변경하면 좋을 것 같은데 몰리 의견이 궁금합니다
  - 그리고 실질적 변경사항이 있는 프로젝트만 실행가능하면 더 좋을것 같은데 되는진 모르겠네요..