### PR TITLE
삼성브라우저에서 이미지 크기 조절되지 않는 현상 수정

### DIFF
--- a/pages/postSiteForm/index.html
+++ b/pages/postSiteForm/index.html
@@ -195,18 +195,21 @@
       }
       .form-image-figure {
         margin-bottom: 20px;
-        img {
-          width: 100%;
-        }
-        figcaption {
-          font-size: .75rem;
-          text-align: right;
-          display: block;
-          a {
-            color: #868686;
-            text-decoration: none;
-          }
-        }
+      }
+
+      .form-image-figure img {
+        width: 100%;
+      }
+
+      .form-image-figure figcaption {
+        font-size: .75rem;
+        text-align: right;
+        display: block;
+      }
+
+      .form-image-figure figcaption a {
+        color: #868686;
+        text-decoration: none;
       }
 
       input::placeholder {


### PR DESCRIPTION
Close #34 

## Done
- 잘못 사용된 css 수정

## To Reviewer
- scss에 너무 익숙해져서 css 를 scss처럼 작성해서 인식을 못하던거였습니다.. ㅠ
- 근데 크롬은 그래도 잘 해줬네요 😮