### PR TITLE
news-scraper-agent 를 sam 으로 배포하도록 코드 수정 

### DIFF
--- a/news-scraper-agent/Dockerfile
+++ b/news-scraper-agent/Dockerfile
@@ -1,0 +1,19 @@
+FROM public.ecr.aws/lambda/python:3.12
+
+ENV POETRY_VERSION=1.8.3
+ENV PYTHONPATH=/var/task
+
+# poetry install
+RUN pip install "poetry==$POETRY_VERSION"
+
+# Copy all files to container
+COPY . /var/task/
+
+WORKDIR /var/task
+
+# Replace profile in .env and install poetry
+RUN sed -i 's/PROFILE="local"/PROFILE="dev"/g' .env \
+    && poetry config virtualenvs.create false \
+    && poetry install --no-interaction
+
+CMD [ "main.lambda_handler" ]

--- a/news-scraper-agent/main.py
+++ b/news-scraper-agent/main.py
@@ -1,31 +1,23 @@
-from config.log import logger
 from graph.build_graph import build_graph
-from graph.state import State
 from loader.connect import connect_db
 
 
-# from utils import get_graph_image
-
-
-def main():
+def main() -> None:
     connect_db()
+    from graph.state import State
+
     initial_state: State = State(
         sites=[],
         parallel_result={},
     )
     graph = build_graph(initial_state)
     #     get_graph_image(graph)
-    return graph.invoke(initial_state)
+    graph.invoke(initial_state)
+
+
+def lambda_handler(event, context) -> None:
+    main()
 
 
 if __name__ == "__main__":
-    result = main()
-    logger.info(result)
-# FIXME 자세한 로그를 보기 위해 우선 주석
-#     try:
-#         result = main()
-#         logger.info(result)
-#         exit(0)  # 성공적으로 종료
-#     except Exception as e:
-#         logger.error(f"An error occurred: {e}")
-#         exit(1)  # 오류로 인한 종료
+    main()

--- a/news-scraper-agent/samconfig.toml
+++ b/news-scraper-agent/samconfig.toml
@@ -1,0 +1,32 @@
+# More information about the configuration file can be found here:
+# https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-config.html
+version = 0.1
+
+[default]
+[default.global.parameters]
+stack_name = "news-scraper-agent"
+
+[default.build.parameters]
+parallel = true
+
+[default.validate.parameters]
+lint = true
+
+[default.deploy.parameters]
+capabilities = "CAPABILITY_NAMED_IAM"
+confirm_changeset = true
+resolve_s3 = true
+resolve_image_repos = false
+image_repositories = ["NewsScraperAgentFunction=339712918956.dkr.ecr.ap-northeast-2.amazonaws.com/ai-news-agent/news-scraper-agent"]
+
+[default.package.parameters]
+resolve_s3 = true
+
+[default.sync.parameters]
+watch = true
+
+[default.local_start_api.parameters]
+warm_containers = "EAGER"
+
+[default.local_start_lambda.parameters]
+warm_containers = "EAGER"

--- a/news-scraper-agent/template.yaml
+++ b/news-scraper-agent/template.yaml
@@ -1,0 +1,65 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: >
+  python3.12
+
+  Sample SAM Template for news-scraper-agent
+
+Resources:
+  NewsScraperAgentFunction:
+    Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
+    Properties:
+      FunctionName: news-scraper-agent
+      ImageUri: 339712918956.dkr.ecr.ap-northeast-2.amazonaws.com/ai-news-agent/news-scraper-agent
+      Timeout: 300 # 300초 (5분)
+      MemorySize: 512
+      PackageType: Image
+      Architectures:
+        - arm64
+      Role: !GetAtt NewsScraperAgentFunctionRole.Arn
+      Tags:
+        PROJECT: AI_NEWS_AGENT
+    Metadata:
+      Dockerfile: Dockerfile
+      DockerContext: ./
+  NewsScraperAgentFunctionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: news-scraper-agent-function-role
+      Tags:
+        - Key: PROJECT
+          Value: AI_NEWS_AGENT
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: LambdaECRAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ecr:GetAuthorizationToken
+                  - ecr:BatchCheckLayerAvailability
+                  - ecr:GetDownloadUrlForLayer
+                  - ecr:BatchGetImage
+                Resource: arn:aws:ecr:ap-northeast-2:339712918956:repository/ai-news-agent/news-scraper-agent
+        - PolicyName: LambdaCloudWatchLogsAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: arn:aws:logs:ap-northeast-2:339712918956:log-group:/aws/lambda/news-scraper-agent:*
+
+Outputs:
+  NewsScraperAgentFunction:
+    Description: "News Scraper Agent Function ARN"
+    Value: !GetAtt NewsScraperAgentFunction.Arn

--- a/news-scraper-agent/template.yaml
+++ b/news-scraper-agent/template.yaml
@@ -19,6 +19,13 @@ Resources:
       Role: !GetAtt NewsScraperAgentFunctionRole.Arn
       Tags:
         PROJECT: AI_NEWS_AGENT
+      Events:
+        Schedule:
+          Type: ScheduleV2
+          Properties:
+            ScheduleExpression: 'cron(0 10 ? * 2-6 * )'
+            Name: news-scraper-agent
+            Description: news-scraper-agent daily scheduler
     Metadata:
       Dockerfile: Dockerfile
       DockerContext: ./
@@ -49,6 +56,16 @@ Resources:
                   - ecr:BatchGetImage
                 Resource: arn:aws:ecr:ap-northeast-2:339712918956:repository/ai-news-agent/news-scraper-agent
         - PolicyName: LambdaCloudWatchLogsAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: arn:aws:logs:ap-northeast-2:339712918956:log-group:/aws/lambda/news-scraper-agent:*
+        - PolicyName: EventBridgeSchedule
           PolicyDocument:
             Version: '2012-10-17'
             Statement:

--- a/samconfig.toml
+++ b/samconfig.toml
@@ -1,0 +1,35 @@
+# More information about the configuration file can be found here:
+# https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-config.html
+version = 0.1
+
+[default]
+[default.global.parameters]
+stack_name = "ai-news-agent"
+
+[default.build.parameters]
+parallel = true
+
+[default.validate.parameters]
+lint = true
+
+[default.deploy.parameters]
+capabilities = "CAPABILITY_NAMED_IAM"
+confirm_changeset = true
+resolve_s3 = true
+resolve_image_repos = false
+image_repositories = [
+    "NewsScraperAgentFunction=339712918956.dkr.ecr.ap-northeast-2.amazonaws.com/ai-news-agent/news-scraper-agent",
+    "ScraperLambdaFunction=339712918956.dkr.ecr.ap-northeast-2.amazonaws.com/ai-news-agent/scraper-lambda"
+]
+
+[default.package.parameters]
+resolve_s3 = true
+
+[default.sync.parameters]
+watch = true
+
+[default.local_start_api.parameters]
+warm_containers = "EAGER"
+
+[default.local_start_lambda.parameters]
+warm_containers = "EAGER"

--- a/template.yaml
+++ b/template.yaml
@@ -1,0 +1,157 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: >
+  python3.12
+
+  Sample SAM Template for ai-news-agent
+
+Resources:
+  NewsScraperAgentFunction:
+    Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
+    Properties:
+      FunctionName: news-scraper-agent
+      ImageUri: 339712918956.dkr.ecr.ap-northeast-2.amazonaws.com/ai-news-agent/news-scraper-agent
+      Timeout: 300 # 300초 (5분)
+      MemorySize: 512
+      PackageType: Image
+      Architectures:
+        - arm64
+      Role: !GetAtt NewsScraperAgentFunctionRole.Arn
+      Tags:
+        PROJECT: AI_NEWS_AGENT
+      Events:
+        Schedule:
+          Type: ScheduleV2
+          Properties:
+            ScheduleExpression: 'cron(0 10 ? * 2-6 * )'
+            Name: news-scraper-agent
+            Description: news-scraper-agent daily scheduler
+      Policies:
+        - LambdaInvokePolicy:
+            FunctionName:
+              !Ref ScraperLambdaFunction
+      Environment:
+        Variables:
+          SCRAPER_LAMBDA_FUNCTION: !Ref ScraperLambdaFunction
+    Metadata:
+      Dockerfile: Dockerfile
+      DockerContext: ./news-scraper-agent
+    DependsOn: NewsScraperAgentFunctionRole
+
+  ScraperLambdaFunction:
+    Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
+    Properties:
+      FunctionName: scraper-lambda
+      ImageUri: 339712918956.dkr.ecr.ap-northeast-2.amazonaws.com/ai-news-agent/scraper-lambda
+      Timeout: 200 # 200초
+      MemorySize: 512
+      PackageType: Image
+      Architectures:
+        - arm64
+      Role: !GetAtt ScraperLambdaFunctionRole.Arn
+      Tags:
+        PROJECT: AI_NEWS_AGENT
+    Metadata:
+      Dockerfile: Dockerfile
+      DockerContext: ./scraper-lambda/src
+    DependsOn: ScraperLambdaFunctionRole
+
+  NewsScraperAgentFunctionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: news-scraper-agent-function-role
+      Tags:
+        - Key: PROJECT
+          Value: AI_NEWS_AGENT
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: LambdaECRAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ecr:GetAuthorizationToken
+                  - ecr:BatchCheckLayerAvailability
+                  - ecr:GetDownloadUrlForLayer
+                  - ecr:BatchGetImage
+                Resource: arn:aws:ecr:ap-northeast-2:339712918956:repository/ai-news-agent/news-scraper-agent
+        - PolicyName: LambdaCloudWatchLogsAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: arn:aws:logs:ap-northeast-2:339712918956:log-group:/aws/lambda/news-scraper-agent:*
+        - PolicyName: EventBridgeSchedule
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: arn:aws:logs:ap-northeast-2:339712918956:log-group:/aws/lambda/news-scraper-agent:*
+        - PolicyName: LambdaInvokePermission
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - lambda:InvokeFunction
+                Resource: !GetAtt ScraperLambdaFunction.Arn
+
+  ScraperLambdaFunctionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: scraper-lambda-function-role
+      Tags:
+        - Key: PROJECT
+          Value: AI_NEWS_AGENT
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: LambdaECRAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ecr:GetAuthorizationToken
+                  - ecr:BatchCheckLayerAvailability
+                  - ecr:GetDownloadUrlForLayer
+                  - ecr:BatchGetImage
+                Resource: arn:aws:ecr:ap-northeast-2:339712918956:repository/ai-news-agent/scraper-lambda
+        - PolicyName: LambdaCloudWatchLogsAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: arn:aws:logs:ap-northeast-2:339712918956:log-group:/aws/lambda/scraper-lambda:*
+
+Outputs:
+  NewsScraperAgentFunction:
+    Description: "News Scraper Agent Function ARN"
+    Value: !GetAtt NewsScraperAgentFunction.Arn
+  ScraperLambdaFunction:
+    Description: "Scraper Lambda Function ARN"
+    Value: !GetAtt ScraperLambdaFunction.Arn


### PR DESCRIPTION
Close #58 

## 변경 사항
- news-scraper-agent 내에 template.yaml 추가
   - 개별 람다만 local invoke 해보기 위해 각 모듈 내에는 있는 template.yaml 은 삭제하지 않았습니다. 
- 최상위 폴더에 template.yaml 추가
![image](https://github.com/user-attachments/assets/96733456-5419-49ba-9263-f4c65f1d3ca5)
- 정상적으로 생성되고, 람다 실행도 잘 되는 것까지는 확인했습니다! 
   <img width="340" alt="image" src="https://github.com/user-attachments/assets/8b529a70-6d76-4296-b74a-a95cb6eed18a">
   - invoke 권한을 role 생성 시에 같이 줘야 하더라구요!
- 로그가 그런데 이런 식으로 남더라구요 ... 터미널에 표시되는 라인 한개당 클라우드와치 한줄 인 것 같습니다.
   <img width="1032" alt="image" src="https://github.com/user-attachments/assets/fea45eef-4697-40d6-98cc-65d6c32c2657">
   <img width="1115" alt="image" src="https://github.com/user-attachments/assets/8160b01d-8b88-4c60-be88-e9f9a3152955">
   - 뭔가 로컬에서는 그 작업해주신대로 그 예쁜 테이블 형태로 표시되는데 클라우드와치(dev, prod)에서는 그냥 한줄에 표시하는게 더 편할 수도 있을 것 같은데 어떻게 생각하시나요?