### PR TITLE
Bug/#83 람다에서 발생하는 버그 보완

### DIFF
--- a/scraper-lambda/src/app.py
+++ b/scraper-lambda/src/app.py
@@ -95,10 +95,10 @@ def handler(event, context) -> dict:
                     headless=True,
                 )
                 page = browser.new_page()
-                page.goto(url, wait_until="load", timeout=60000) # 70초
-                page.wait_for_load_state("networkidle", timeout=60000) # 70초
+                page.goto(url, wait_until="domcontentloaded", timeout=70000) # 70초
+                page.wait_for_load_state("networkidle", timeout=70000) # 70초
                 if selector:
-                    page.wait_for_selector(selector, timeout=10000) # 20초
+                    page.wait_for_selector(selector, timeout=10000) # 10초
                     selected: list[ElementHandle] = page.query_selector_all(selector)
                     if len(selected) == 0:
                         return error(f"Element not found with {selector}", 400)

--- a/scraper-lambda/src/app.py
+++ b/scraper-lambda/src/app.py
@@ -95,25 +95,24 @@ def handler(event, context) -> dict:
                     headless=True,
                 )
                 page = browser.new_page()
-                page.goto(url, timeout=80000) # 80초
-                page.wait_for_load_state("networkidle", timeout=80000) # 80초
-                page_content = page.content()
-                result = [page_content]
+                page.goto(url, wait_until="load", timeout=60000) # 70초
+                page.wait_for_load_state("networkidle", timeout=60000) # 70초
                 if selector:
+                    page.wait_for_selector(selector, timeout=10000) # 20초
                     selected: list[ElementHandle] = page.query_selector_all(selector)
                     if len(selected) == 0:
                         return error(f"Element not found with {selector}", 400)
                     result = list(map(lambda x: x.evaluate("(element) => element.outerHTML"), selected))
-                browser.close()
-            return success(result)
+                else:
+                    page_content = page.content()
+                    result = [page_content]
+                return success(result)
         except PlaywrightTimeoutError:
             print(f"HTML rendering timed out: {url}")
             return error("HTML rendering timed out", 408)
         except Exception as e:
             print(f"An unexpected error occurred: {str(e)}")
             return error(f"An unexpected error occurred: {str(e)}", 500)
-        finally:
-            browser.close()
 
     else:
         print(f"Invalid content type: {content_type}")

--- a/scraper-lambda/src/app.py
+++ b/scraper-lambda/src/app.py
@@ -112,6 +112,8 @@ def handler(event, context) -> dict:
         except Exception as e:
             print(f"An unexpected error occurred: {str(e)}")
             return error(f"An unexpected error occurred: {str(e)}", 500)
+        finally:
+            browser.close()
 
     else:
         print(f"Invalid content type: {content_type}")

--- a/scraper-lambda/src/app.py
+++ b/scraper-lambda/src/app.py
@@ -107,11 +107,12 @@ def handler(event, context) -> dict:
                     page_content = page.content()
                     result = [page_content]
                 return success(result)
-        except PlaywrightTimeoutError:
+        except PlaywrightTimeoutError as e:
+            print(f"playwright timeout: {e}")
             print(f"HTML rendering timed out: {url}")
             return error("HTML rendering timed out", 408)
         except Exception as e:
-            print(f"An unexpected error occurred: {str(e)}")
+            print(f"An unexpected error occurred: {e}")
             return error(f"An unexpected error occurred: {str(e)}", 500)
 
     else:

--- a/scraper-lambda/tests/unit/test_handler.py
+++ b/scraper-lambda/tests/unit/test_handler.py
@@ -42,3 +42,28 @@ def test_json():
     assert resp["statusCode"] == 200
     assert "result" in data
     assert data["result"]["username"] == "Bret"
+
+
+def test_devocean():
+    resp = app.handler({
+        "url": "https://devocean.sk.com/blog/index.do?techType=NEWS",
+        "content_type": "html",
+        "selector": "div.sec-area > ul.sec-area-list01 > li:first-child > div a > h3.pc_view"
+    }, "")
+    data = json.loads(resp["body"])
+
+    assert resp["statusCode"] == 200
+    assert "result" in data
+    assert data["result"] is not None
+
+def test_sds():
+    resp = app.handler({
+        "url": "https://www.samsungsds.com/kr/insights/index.html?moreCnt=0&backTypeId=&category=&reqArtId=1282554",
+        "content_type": "html",
+        "selector": ".cont_list .item strong.md_tit"
+    }, "")
+    data = json.loads(resp["body"])
+
+    assert resp["statusCode"] == 200
+    assert "result" in data
+    assert data["result"] is not None

--- a/scraper-lambda/tests/unit/test_handler.py
+++ b/scraper-lambda/tests/unit/test_handler.py
@@ -1,9 +1,7 @@
 import json
 
-import pytest
 
 from src import app
-from src.used_type import RequestBody
 
 
 def test_static_page():


### PR DESCRIPTION
Close #83 

해당 에러가 로직상 원인이 확실하지 않고.. 외부 서버나 네트워크 등 고려할게 많아서 이번 수정으로 확실히 고쳤다고는 말하기 힘드네요
이 변경사항이 적용된 후에도 좀 살펴봐야 할 것 같습니다..
크게
- timeout과 관련된 문제 발생을 막기위한 보완조치
- playwright와 관련된 리소스 해제시 발생하는 것으로 보이는 문제를 막기위한 보완조치

를 했습니다 

## 변경사항
- 명시적 `browser.close()` 호출을 삭제
- page.goto에서 wait_until을 `documentloaded`로 수정
  - 기본값은 `load` 인데, 이는 document 및 스타일, js, 이미지 등 모든 리소스가 로드되고 나서 발생하는 이벤트입니다
  - 정보수집에 불필요한 리소스도 기다릴 수 있기 때문에 이를 `documentloaded`로 바꿔 문서 로드만 기다리도록 했습니다
  - 하지만 이렇게하는 경우 클라이언트 렌더링 사이트에서는 모든 데이터를 확인할 수 없기 때문에 네트워크 커넥션이 500ms 동안 없기를 기다리는 `networkidle`까지 대기해 줍니다
- selector가 있는 경우 `wait_for_selector`를 추가
  - 위의 `documentloaded`, `networkidle`이 완료가되면 모든 리소스가 다 로드되지 않더라도 selector에 해당하는 요소가 렌더링되면 데이터 수집을 시작할 수 있도록 했습니다
- playwright timeout 에러시 print문 추가
- 상대적으로 복잡한 사이트인 데보션, 삼성sds에 대한 테스트코드 추가
  - 주로 이 두 사이트에서 문제가 발생하는 것 같아 추가했습니다
  - 로컬에서 테스트 좀 했더니 저 타임아웃을 모두 기다려도 렌더링이 되지 않는 경우도 있더라고요(딱 한번).. 항상 발생하는게 아닌걸 봐서는 저쪽 서버환경도 관련있을 수 있어 이런 케이스는 재시도 추가(#81)로 어느정도 보완할 수밖에 없을 것 같네요

## To reviewer
- 대기쪽은 좀 복잡할 수 있어서 한번 더 정리하자면
  - 기존: `load` 이벤트를 대기 (기본값)
    - document, js, css, 이미지, 동영상 등 필요한 모든 리소스가 로드된 후 발생
    - 가능한 모든 리소스가 로딩되어 상대적으로 안정적인 상태를 얻을 수 있지만 특정 무거운 리소스가 있거나 특정 cdn 등이 불안정하다던지 하면 timeout의 원인이 될 수 있음
  - 수정: `documentloaded`를 대기 + `wait_for_selector` 사용
    - `documentloaded`로 html 문서가 로드되는것 까지만 대기 후 다음대기(`networkidle`)로 넘어감
      - 위 처럼 정보수집에 불필요한 리소스 때문에 대기가 길어지는 것을 방지
    - 그 이후에 `networkidle`대기 (기존과 동일, 500ms동안 커넥션이 없을때까지 대기)
    - 위 두가지를 만족한 경우에도 특정 api는 응답이 오지 않은 상태가 될 수 있음 (해당 요청이 수집 대상 데이터에 대한 api 요청인 경우 문제가 됨)
    - 따라서 이 경우 10초동안 더 기다려서 수집 대상 데이터가 있는 요소의 존재를 어느정도 보장해주기 위해 `wait_for_selector` 추가
- `context or browser has been closed` 에러는 이미 context나 browser가 닫혔다는 의미로 playwright가 의도치 않게 중지되었을 때 발생할 수 있다고 하네요
  - 현재 with 구문 안에서 `browser.close()`를 호출하고 있습니다
  - with를 벗어날 때 sync_playwright와 관련된 리소스는 자동으로 해제가 되는데 with 구문안에서 이미 `browser`의 `close`가 호출되어 해당 에러가 발생할 수 있을 것 같아 명시적 호출을 제거하고 리소스 매니저가 모두 수행하도록 했습니다.
- `waiting until load`는 에러는 아니고 goto 호출 시 기본 wait_until이 load로 되어있어 document의 load 이벤트를 기다리는 중이라는 알림 목적읠 로그라고 하네요
  - 그래도 가끔씩 발생하는 timeout 관련 문제를 이번에 수정하면서 좀 더 보완할 수 있을 것 같아 위 내용(wait 관련)을 추가했습니다