### PR TITLE
CloudWatch에서 로그 표시 수정

### DIFF
--- a/news-scraper-agent/README.md
+++ b/news-scraper-agent/README.md
@@ -11,6 +11,16 @@ poetry install
 python {파일명}.py
 ```
 
+## 배포 방법
+```shell
+# 로컬에서 실행 방법 
+sam local invoke
+
+# 빌드 후 배포
+sam build
+sam deploy
+```
+
 ## memo
 - 현재는 langsmith 로 연결해두었는데 .. 만약에 이게 사내망에서 서비스 하는 걸로 변경된다면 langfuse 써보기!
 - 의존성 내보내기

--- a/news-scraper-agent/agents/crawling_agent.py
+++ b/news-scraper-agent/agents/crawling_agent.py
@@ -1,7 +1,6 @@
 from langchain.prompts import PromptTemplate
 from langchain_core.language_models import BaseLanguageModel
 
-from config.env_config import env
 from config.log import create_logger
 from config.prompt_config import DefaultPromptTemplate
 from decorations.log_time import log_time_agent_method
@@ -54,5 +53,5 @@ class CrawlingAgent:
             self.logger.error(f"Error occurred while crawling {self.site.name}: {e}")
             state.crawling_result[self.site.name] = []
 
-        state.print_state(env.PROFILE, crawling_result=True)
+        state.print_state(crawling_result=True)
         return state

--- a/news-scraper-agent/agents/crawling_agent.py
+++ b/news-scraper-agent/agents/crawling_agent.py
@@ -1,7 +1,7 @@
 from langchain.prompts import PromptTemplate
 from langchain_core.language_models import BaseLanguageModel
 
-from config.log import create_logger
+from config.log import NewsScraperAgentLogger
 from config.prompt_config import DefaultPromptTemplate
 from decorations.log_time import log_time_agent_method
 from graph.state import (
@@ -18,8 +18,7 @@ class CrawlingAgent:
     )
 
     def __init__(self, llm: BaseLanguageModel, site: SiteDto, prompt: str = None):
-        logger = create_logger(self.__class__.__name__)
-        self.logger = logger
+        self.logger = NewsScraperAgentLogger(self.__class__.__name__)
         self.prompt = PromptTemplate.from_template(
             prompt if prompt else self.crawling_prompt
         )

--- a/news-scraper-agent/agents/crawling_agent.py
+++ b/news-scraper-agent/agents/crawling_agent.py
@@ -1,6 +1,7 @@
 from langchain.prompts import PromptTemplate
 from langchain_core.language_models import BaseLanguageModel
 
+from config.env_config import env
 from config.log import create_logger
 from config.prompt_config import DefaultPromptTemplate
 from decorations.log_time import log_time_agent_method
@@ -53,5 +54,5 @@ class CrawlingAgent:
             self.logger.error(f"Error occurred while crawling {self.site.name}: {e}")
             state.crawling_result[self.site.name] = []
 
-        state.print_state(crawling_result=True)
+        state.print_state(env.PROFILE, crawling_result=True)
         return state

--- a/news-scraper-agent/agents/filtering_agent.py
+++ b/news-scraper-agent/agents/filtering_agent.py
@@ -1,7 +1,7 @@
 from langchain.prompts import PromptTemplate
 from langchain_core.language_models import BaseLanguageModel
 
-from config.log import create_logger
+from config.log import NewsScraperAgentLogger
 from config.prompt_config import DefaultPromptTemplate
 from decorations.log_time import log_time_agent_method
 from graph.state import SiteState, AgentResponse
@@ -15,8 +15,7 @@ class FilteringAgent:
     )
 
     def __init__(self, llm: BaseLanguageModel, site: SiteDto, prompt: str = None):
-        logger = create_logger(self.__class__.__name__)
-        self.logger = logger
+        self.logger = NewsScraperAgentLogger(self.__class__.__name__)
         self.site = site
         self.prompt = PromptTemplate.from_template(
             prompt if prompt else self.filtering_prompt

--- a/news-scraper-agent/agents/filtering_agent.py
+++ b/news-scraper-agent/agents/filtering_agent.py
@@ -1,6 +1,7 @@
 from langchain.prompts import PromptTemplate
 from langchain_core.language_models import BaseLanguageModel
 
+from config.env_config import env
 from config.log import create_logger
 from config.prompt_config import DefaultPromptTemplate
 from decorations.log_time import log_time_agent_method
@@ -48,5 +49,5 @@ class FilteringAgent:
             self.logger.error(f"Error occurred while filtering {self.site.name}: {e}")
             state.filtering_result[self.site.name] = []
 
-        state.print_state(filtering_result=True)
+        state.print_state(env.PROFILE, filtering_result=True)
         return state

--- a/news-scraper-agent/agents/filtering_agent.py
+++ b/news-scraper-agent/agents/filtering_agent.py
@@ -1,7 +1,6 @@
 from langchain.prompts import PromptTemplate
 from langchain_core.language_models import BaseLanguageModel
 
-from config.env_config import env
 from config.log import create_logger
 from config.prompt_config import DefaultPromptTemplate
 from decorations.log_time import log_time_agent_method
@@ -49,5 +48,5 @@ class FilteringAgent:
             self.logger.error(f"Error occurred while filtering {self.site.name}: {e}")
             state.filtering_result[self.site.name] = []
 
-        state.print_state(env.PROFILE, filtering_result=True)
+        state.print_state(filtering_result=True)
         return state

--- a/news-scraper-agent/agents/html_parser_agent.py
+++ b/news-scraper-agent/agents/html_parser_agent.py
@@ -3,7 +3,7 @@ import re
 from typing import TypedDict, Literal, NotRequired
 
 
-from config.log import create_logger
+from config.log import NewsScraperAgentLogger
 from decorations.log_time import log_time_agent_method
 from external.aws_lambda.client import LambdaInvoker
 from graph.state import SiteState
@@ -18,10 +18,9 @@ class ParsingLambdaRequestBody(TypedDict):
 
 class HtmlParserAgent:
     def __init__(self, site: SiteDto):
-        logger = create_logger(self.__class__.__name__)
-        self.logger = logger
+        self.logger = NewsScraperAgentLogger(self.__class__.__name__)
         self.site = site
-        self.lambda_invoker = LambdaInvoker(logger=logger)
+        self.lambda_invoker = LambdaInvoker()
 
     @log_time_agent_method
     def __call__(self, state: SiteState = None) -> SiteState:

--- a/news-scraper-agent/agents/message_agent.py
+++ b/news-scraper-agent/agents/message_agent.py
@@ -1,15 +1,13 @@
-from rich.console import Console
-from rich.table import Table
-
 from config.env_config import env
-from config.log import create_logger
+from config.log import create_logger, console_print, ConsoleDataType
 from decorations.log_time import log_time_agent_method
 from external.kakaowork.client import KakaoworkClient
+from external.kakaowork.message_builder import KakaoworkMessageBuilder
 from graph.state import State, CrawlingResult, PageCrawlingData
 from models.message import Message
 from models.message import MessageContent, MessageContentDto
+from rich.table import Table
 from service.message_service import get_messages
-from external.kakaowork.message_builder import KakaoworkMessageBuilder
 
 MESSAGE_TYPE = "KAKAOWORK"
 SEND_MESSAGE_SUCCESS = "SEND_MESSAGE_SUCCESS"
@@ -19,7 +17,6 @@ SEND_MESSAGE_FAIL = "SEND_MESSAGE_FAIL"
 class MessageAgent:
     def __init__(self):
         self.logger = create_logger(self.__class__.__name__)
-        self.console = Console()
 
     @log_time_agent_method
     def __call__(self, state: State) -> None:
@@ -60,8 +57,11 @@ class MessageAgent:
         }
 
         if env.ENABLE_MESSAGE_AGENT_LOG:
-            table = self._get_parallel_result_table(unique_parallel_result)
-            self.console.print(table)
+            console_print(
+                ConsoleDataType.TABLE,
+                self._get_parallel_result_table(unique_parallel_result),
+                self.logger,
+            )
 
         # 6. unique_parallel_result를 카카오워크 메세지로 생성
         request = KakaoworkMessageBuilder().build(unique_parallel_result)
@@ -91,7 +91,7 @@ class MessageAgent:
         table.add_column("url", overflow="fold")
         table.add_column("title", style="magenta", overflow="fold")
         for idx_1, (site_name, page_crawling_data) in enumerate(
-            result.items(), start=1
+                result.items(), start=1
         ):
             for idx_2, item in enumerate(page_crawling_data, start=1):
                 table.add_row(str(idx_1 + idx_2 - 1), site_name, item.url, item.title)

--- a/news-scraper-agent/agents/message_agent.py
+++ b/news-scraper-agent/agents/message_agent.py
@@ -1,5 +1,5 @@
 from config.env_config import env
-from config.log import create_logger, console_print, ConsoleDataType
+from config.log import ConsoleDataType, NewsScraperAgentLogger
 from decorations.log_time import log_time_agent_method
 from external.kakaowork.client import KakaoworkClient
 from external.kakaowork.message_builder import KakaoworkMessageBuilder
@@ -16,7 +16,7 @@ SEND_MESSAGE_FAIL = "SEND_MESSAGE_FAIL"
 
 class MessageAgent:
     def __init__(self):
-        self.logger = create_logger(self.__class__.__name__)
+        self.logger = NewsScraperAgentLogger(self.__class__.__name__)
 
     @log_time_agent_method
     def __call__(self, state: State) -> None:
@@ -57,10 +57,9 @@ class MessageAgent:
         }
 
         if env.ENABLE_MESSAGE_AGENT_LOG:
-            console_print(
+            self.logger.console_print(
                 ConsoleDataType.TABLE,
                 self._get_parallel_result_table(unique_parallel_result),
-                self.logger,
             )
 
         # 6. unique_parallel_result를 카카오워크 메세지로 생성
@@ -85,13 +84,13 @@ class MessageAgent:
         message.save()
 
     def _get_parallel_result_table(self, result: CrawlingResult) -> Table:
-        table = Table(title="unique_parallel_result")
+        table = Table(title="unique_parallel_result", title_justify="left")
         table.add_column("idx", no_wrap=True)
         table.add_column("site_name", style="cyan", no_wrap=True)
         table.add_column("url", overflow="fold")
         table.add_column("title", style="magenta", overflow="fold")
         for idx_1, (site_name, page_crawling_data) in enumerate(
-                result.items(), start=1
+            result.items(), start=1
         ):
             for idx_2, item in enumerate(page_crawling_data, start=1):
                 table.add_row(str(idx_1 + idx_2 - 1), site_name, item.url, item.title)

--- a/news-scraper-agent/agents/sorting_agent.py
+++ b/news-scraper-agent/agents/sorting_agent.py
@@ -1,7 +1,6 @@
 from langchain.prompts import PromptTemplate
 from langchain_core.language_models import BaseLanguageModel
 
-from config.env_config import env
 from config.log import create_logger
 from config.prompt_config import DefaultPromptTemplate
 from decorations.log_time import log_time_agent_method
@@ -55,5 +54,5 @@ class SortingAgent:
                 for result in state.filtering_result[self.site.name]
             ]
 
-        state.print_state(env.PROFILE, sorted_result=True)
+        state.print_state(sorted_result=True)
         return state

--- a/news-scraper-agent/agents/sorting_agent.py
+++ b/news-scraper-agent/agents/sorting_agent.py
@@ -1,7 +1,7 @@
 from langchain.prompts import PromptTemplate
 from langchain_core.language_models import BaseLanguageModel
 
-from config.log import create_logger
+from config.log import NewsScraperAgentLogger
 from config.prompt_config import DefaultPromptTemplate
 from decorations.log_time import log_time_agent_method
 from graph.state import SiteState, SortAgentResponse, SortedFilteringData
@@ -15,8 +15,7 @@ class SortingAgent:
     )
 
     def __init__(self, llm: BaseLanguageModel, site: SiteDto, prompt: str = None):
-        logger = create_logger(self.__class__.__name__)
-        self.logger = logger
+        self.logger = NewsScraperAgentLogger(self.__class__.__name__)
         self.site = site
         self.prompt = PromptTemplate.from_template(
             prompt if prompt else self.sorting_prompt

--- a/news-scraper-agent/agents/sorting_agent.py
+++ b/news-scraper-agent/agents/sorting_agent.py
@@ -1,6 +1,7 @@
 from langchain.prompts import PromptTemplate
 from langchain_core.language_models import BaseLanguageModel
 
+from config.env_config import env
 from config.log import create_logger
 from config.prompt_config import DefaultPromptTemplate
 from decorations.log_time import log_time_agent_method
@@ -54,5 +55,5 @@ class SortingAgent:
                 for result in state.filtering_result[self.site.name]
             ]
 
-        state.print_state(sorted_result=True)
+        state.print_state(env.PROFILE, sorted_result=True)
         return state

--- a/news-scraper-agent/config/log.py
+++ b/news-scraper-agent/config/log.py
@@ -27,57 +27,62 @@ class KSTFormatter(logging.Formatter):
         return dt.isoformat()
 
 
-# Formatter 설정
-formatter = KSTFormatter(
-    fmt="%(asctime)s - %(name)16s - %(levelname)7s - %(message)s",
-    datefmt="%Y-%m-%d %H:%M:%S",
-)
+class NewsScraperAgentLogger(logging.Logger):
+    def __init__(self, name: str = "NewsScraperAgent"):
+        super().__init__(name)
 
-# Logger 설정
-default_logger = logging.getLogger("NewsScraperAgent")
-default_logger.setLevel(logging.DEBUG if env.PROFILE != "real" else logging.INFO)
+        self.console = Console()
+        self._initialize_logger()
 
-# RichHandler 추가
-console = Console()
-rich_handler = RichHandler(rich_tracebacks=True, console=console)
-rich_handler.setLevel(logging.DEBUG)
-rich_handler.setFormatter(formatter)
-default_logger.addHandler(rich_handler)
+    def _initialize_logger(self):
+        # Formatter 설정
+        formatter = KSTFormatter(
+            fmt="%(asctime)s - %(name)16s - %(levelname)7s - %(message)s",
+            datefmt="%Y-%m-%d %H:%M:%S",
+        )
 
+        # Logger 레벨 설정
+        self.setLevel(logging.DEBUG if env.PROFILE != "real" else logging.INFO)
 
-# logger 객체 추가
-def create_logger(name: str) -> logging.Logger:
-    logger = logging.getLogger(name)
-    logger.setLevel(logging.DEBUG if env.PROFILE != "real" else logging.INFO)
-    logger.addHandler(rich_handler)
-    return logger
+        # RichHandler 추가
+        rich_handler = RichHandler(rich_tracebacks=True, console=self.console)
+        rich_handler.setLevel(logging.DEBUG)
+        rich_handler.setFormatter(formatter)
+        self.addHandler(rich_handler)
 
+    def console_print(
+        self, data_type: ConsoleDataType, data: Any, logger_name: str = None
+    ):
+        current_logger = logging.getLogger(logger_name) if logger_name else self
+        display_text = self._to_console_text(data_type, data)
+        current_logger.info(f"{display_text}")
 
-def to_console_text(data_type: ConsoleDataType, data: Any):
-    with console.capture() as capture:
-        if data_type == ConsoleDataType.TABLE and isinstance(data, Table):
-            console.print(data)
-        elif data_type == ConsoleDataType.JSON:
-            console.print(JSON.from_data(data))  # json 문자열로 표시 (" 포함)
-        elif data_type == ConsoleDataType.DICT:
-            console.print(JSON.from_data(data))  # dict를 json 형태로 예쁘게 표시
-        elif data_type == ConsoleDataType.TEXT:
-            console.print(data)
-    return Text.from_ansi(capture.get())
-
-
-def console_print(data_type: ConsoleDataType, data: Any, logger: logging.Logger = None):
-    display_text = to_console_text(data_type, data)
-    if logger is None:
-        default_logger.info(f"{display_text}")
-    else:
-        logger.info(f"{display_text}")
+    def _to_console_text(self, data_type: ConsoleDataType, data: Any):
+        with self.console.capture() as capture:
+            if data_type == ConsoleDataType.TABLE and isinstance(data, Table):
+                self.console.print(data)
+            elif data_type == ConsoleDataType.JSON:
+                self.console.print(JSON.from_data(data))  # JSON 문자열로 표시 (" 포함)
+            elif data_type == ConsoleDataType.DICT:
+                self.console.print(
+                    JSON.from_data(data)
+                )  # dict를 JSON 형태로 예쁘게 표시
+            elif data_type == ConsoleDataType.TEXT:
+                self.console.print(data)
+        return Text.from_ansi(capture.get())
 
 
 if __name__ == "__main__":
     # 로그 테스트 (python -m config.log)
-    default_logger.debug("Debug message")
-    default_logger.info("Info message")
-    default_logger.warning("Warning message")
-    default_logger.error("Error message")
-    default_logger.critical("Critical message")
+    logger = NewsScraperAgentLogger("NewsScraperAgent")
+
+    # 로그 메시지 테스트
+    logger.debug("Debug message")
+    logger.info("Info message")
+    logger.warning("Warning message")
+    logger.error("Error message")
+    logger.critical("Critical message")
+
+    # console_print 사용 예시
+    sample_data = {"key": "value", "another_key": "another_value"}
+    logger.console_print(ConsoleDataType.DICT, sample_data)

--- a/news-scraper-agent/config/log.py
+++ b/news-scraper-agent/config/log.py
@@ -50,12 +50,9 @@ class NewsScraperAgentLogger(logging.Logger):
         rich_handler.setFormatter(formatter)
         self.addHandler(rich_handler)
 
-    def console_print(
-        self, data_type: ConsoleDataType, data: Any, logger_name: str = None
-    ):
-        current_logger = logging.getLogger(logger_name) if logger_name else self
+    def console_print(self, data_type: ConsoleDataType, data: Any):
         display_text = self._to_console_text(data_type, data)
-        current_logger.info(f"{display_text}")
+        self.info(f"{display_text}")
 
     def _to_console_text(self, data_type: ConsoleDataType, data: Any):
         with self.console.capture() as capture:

--- a/news-scraper-agent/decorations/log_time.py
+++ b/news-scraper-agent/decorations/log_time.py
@@ -1,6 +1,6 @@
 import time
 
-from config.log import create_logger, default_logger
+from config.log import NewsScraperAgentLogger
 
 
 def log_time_agent_method(func):
@@ -8,7 +8,9 @@ def log_time_agent_method(func):
     def wrapper(self, *args, **kwargs):
         has_site = hasattr(self, "site")
         logger = (
-            self.logger if hasattr(self, "logger") and self.logger else default_logger
+            self.logger
+            if hasattr(self, "logger") and self.logger
+            else NewsScraperAgentLogger()
         )
 
         logger.info(
@@ -34,7 +36,9 @@ def log_time_method(func):
     # 일반적인 클래스 메서드에서 사용
     def wrapper(self, *args, **kwargs):
         logger = (
-            self.logger if hasattr(self, "logger") and self.logger else default_logger
+            self.logger
+            if hasattr(self, "logger") and self.logger
+            else NewsScraperAgentLogger()
         )
         logger.info(f"Started {self.__class__.__name__}.{func.__name__}")
 

--- a/news-scraper-agent/external/aws_lambda/client.py
+++ b/news-scraper-agent/external/aws_lambda/client.py
@@ -1,19 +1,14 @@
-import logging
 import time
 
 import boto3
 
-from config.log import create_logger
+from config.log import NewsScraperAgentLogger
 
 
 class LambdaInvoker:
-    def __init__(self, name: str = None, logger: logging.Logger = None):
+    def __init__(self):
         self.client = boto3.client("lambda", region_name="ap-northeast-2")
-        self.logger = (
-            logger
-            if logger is not None
-            else create_logger(name if name else self.__class__.__name__)
-        )
+        self.logger = NewsScraperAgentLogger(self.__class__.__name__)
 
     def invoke(
         self,

--- a/news-scraper-agent/external/kakaowork/client.py
+++ b/news-scraper-agent/external/kakaowork/client.py
@@ -1,9 +1,7 @@
 import requests
-from rich.console import Console
-from rich.json import JSON
 
 from config.env_config import env
-from config.log import create_logger
+from config.log import create_logger, console_print, ConsoleDataType
 from decorations.log_time import log_time_method
 from external.kakaowork.message_blocks import KakaoworkMessageRequest
 
@@ -21,13 +19,16 @@ class KakaoworkClient:
     def __init__(self, profile: str):
         self.webhook_url = WEBHOOK_URL_MAP.get(profile)
         self.logger = create_logger(self.__class__.__name__)
-        self.console = Console()
 
     @log_time_method
     def send_message(self, request: KakaoworkMessageRequest) -> int:
         try:
             self.logger.info("request body 👇")
-            self.console.print(JSON.from_data(request.model_dump(exclude_none=True)))
+            console_print(
+                ConsoleDataType.DICT,
+                request.model_dump(exclude_none=True),
+                self.logger,
+            )
 
             response = requests.post(
                 self.webhook_url,
@@ -36,8 +37,8 @@ class KakaoworkClient:
             )
             # 응답 코드와 상세 정보 로깅
             self.logger.info(f"response status_code: {response.status_code}")
-            self.logger.info(f"response body 👇")  # 응답 본문 텍스트
-            self.console.print(JSON.from_data(response.json()))
+            self.logger.info("response body 👇")  # 응답 본문 텍스트
+            console_print(ConsoleDataType.DICT, response.json(), self.logger)
             return response.status_code
         except requests.RequestException as e:
             self.logger.error(f"Error sending message: {e}")

--- a/news-scraper-agent/external/kakaowork/client.py
+++ b/news-scraper-agent/external/kakaowork/client.py
@@ -1,7 +1,7 @@
 import requests
 
 from config.env_config import env
-from config.log import create_logger, console_print, ConsoleDataType
+from config.log import ConsoleDataType, NewsScraperAgentLogger
 from decorations.log_time import log_time_method
 from external.kakaowork.message_blocks import KakaoworkMessageRequest
 
@@ -18,16 +18,14 @@ WEBHOOK_URL_MAP = {
 class KakaoworkClient:
     def __init__(self, profile: str):
         self.webhook_url = WEBHOOK_URL_MAP.get(profile)
-        self.logger = create_logger(self.__class__.__name__)
+        self.logger = NewsScraperAgentLogger(self.__class__.__name__)
 
     @log_time_method
     def send_message(self, request: KakaoworkMessageRequest) -> int:
         try:
             self.logger.info("request body 👇")
-            console_print(
-                ConsoleDataType.DICT,
-                request.model_dump(exclude_none=True),
-                self.logger,
+            self.logger.console_print(
+                ConsoleDataType.DICT, request.model_dump(exclude_none=True)
             )
 
             response = requests.post(
@@ -38,7 +36,7 @@ class KakaoworkClient:
             # 응답 코드와 상세 정보 로깅
             self.logger.info(f"response status_code: {response.status_code}")
             self.logger.info("response body 👇")  # 응답 본문 텍스트
-            console_print(ConsoleDataType.DICT, response.json(), self.logger)
+            self.logger.console_print(ConsoleDataType.DICT, response.json())
             return response.status_code
         except requests.RequestException as e:
             self.logger.error(f"Error sending message: {e}")

--- a/news-scraper-agent/graph/state.py
+++ b/news-scraper-agent/graph/state.py
@@ -1,3 +1,4 @@
+from config.env_config import env
 from config.log import console_print, create_logger, ConsoleDataType
 from models.site import SiteDto
 from pydantic import BaseModel, Field
@@ -57,15 +58,14 @@ class SiteState(BaseModel):
             console_print(ConsoleDataType.TABLE, table, create_logger(title))
 
     def print_state(
-            self,
-            profile: str = "local",
-            crawling_result: bool = False,
-            filtering_result: bool = False,
-            parser_result: bool = False,
-            sorted_result: bool = False,
+        self,
+        crawling_result: bool = False,
+        filtering_result: bool = False,
+        parser_result: bool = False,
+        sorted_result: bool = False,
     ):
         if parser_result:
-            if profile == "local":
+            if env.PROFILE == "local":
                 self._print_table(
                     title="ParserResult",
                     columns=[
@@ -87,7 +87,7 @@ class SiteState(BaseModel):
                 )
 
         if crawling_result:
-            if profile == "local":
+            if env.PROFILE == "local":
                 self._print_table(
                     title="CrawlingResult",
                     columns=[
@@ -120,7 +120,7 @@ class SiteState(BaseModel):
                 )
 
         if filtering_result:
-            if profile == "local":
+            if env.PROFILE == "local":
                 self._print_table(
                     title="FilteringResult",
                     columns=[
@@ -153,7 +153,7 @@ class SiteState(BaseModel):
                 )
 
         if sorted_result:
-            if profile == "local":
+            if env.PROFILE == "local":
                 self._print_table(
                     title="SortedResult",
                     columns=[

--- a/news-scraper-agent/graph/state.py
+++ b/news-scraper-agent/graph/state.py
@@ -61,9 +61,9 @@ class SiteState(BaseModel):
         parser_result: bool = False,
         sorted_result: bool = False,
     ):
-        logger = NewsScraperAgentLogger("PrintState")
+        logger_name = "ParserResult"
+        logger = NewsScraperAgentLogger(logger_name)
         if parser_result:
-            logger_name = "ParserResult"
             if env.PROFILE == "local":
                 table = self._get_print_table(
                     title=logger_name,
@@ -80,12 +80,11 @@ class SiteState(BaseModel):
                 )
                 logger.console_print(ConsoleDataType.TABLE, table)
             else:
-                logger.console_print(
-                    ConsoleDataType.DICT, self.parser_result, logger_name
-                )
+                logger.console_print(ConsoleDataType.DICT, self.parser_result)
 
         if crawling_result:
             logger_name = "CrawlingResult"
+            logger = NewsScraperAgentLogger(logger_name)
             if env.PROFILE == "local":
                 table = self._get_print_table(
                     title=logger_name,
@@ -113,10 +112,11 @@ class SiteState(BaseModel):
                     site: [item.model_dump() for item in items]
                     for site, items in self.crawling_result.items()
                 }
-                logger.console_print(ConsoleDataType.DICT, dict_result, logger_name)
+                logger.console_print(ConsoleDataType.DICT, dict_result)
 
         if filtering_result:
             logger_name = "FilteringResult"
+            logger = NewsScraperAgentLogger(logger_name)
             if env.PROFILE == "local":
                 table = self._get_print_table(
                     title=logger_name,
@@ -144,10 +144,11 @@ class SiteState(BaseModel):
                     site: [item.model_dump() for item in items]
                     for site, items in self.filtering_result.items()
                 }
-                logger.console_print(ConsoleDataType.DICT, dict_result, logger_name)
+                logger.console_print(ConsoleDataType.DICT, dict_result)
 
         if sorted_result:
             logger_name = "SortedResult"
+            logger = NewsScraperAgentLogger(logger_name)
             if env.PROFILE == "local":
                 table = self._get_print_table(
                     title=logger_name,
@@ -182,7 +183,7 @@ class SiteState(BaseModel):
                     site: [item.model_dump() for item in items]
                     for site, items in self.sorted_result.items()
                 }
-                logger.console_print(ConsoleDataType.DICT, dict_result, logger_name)
+                logger.console_print(ConsoleDataType.DICT, dict_result)
 
 
 class State(BaseModel):

--- a/news-scraper-agent/graph/state.py
+++ b/news-scraper-agent/graph/state.py
@@ -1,9 +1,7 @@
-import rich.table
-from pydantic import BaseModel, Field
-from rich.console import Console
-from rich.table import Table
-
+from config.log import console_print, create_logger, ConsoleDataType
 from models.site import SiteDto
+from pydantic import BaseModel, Field
+from rich.table import Table
 
 
 class SortedFilteringData(BaseModel):
@@ -35,9 +33,11 @@ class SiteState(BaseModel):
         :param columns: 열 정의 리스트 (각 열의 이름, 스타일, overflow 등).
         :param data: 출력할 데이터 딕셔너리.
         """
-        console = Console()
         for site, results in data.items():
-            table = Table(title=f"[{site}] {title}")
+            table = Table(
+                title=f"[{site}] {title}",
+                title_justify="left",
+            )
             # 열 정의 추가
             for column in columns:
                 table.add_column(**{k: v for k, v in column.items() if k != "key"})
@@ -54,78 +54,143 @@ class SiteState(BaseModel):
                             if "key" in column
                         ),
                     )
-            console.print(table)
+            console_print(ConsoleDataType.TABLE, table, create_logger(title))
 
     def print_state(
-        self,
-        crawling_result: bool = False,
-        filtering_result: bool = False,
-        parser_result: bool = False,
-        sorted_result: bool = False,
+            self,
+            profile: str = "local",
+            crawling_result: bool = False,
+            filtering_result: bool = False,
+            parser_result: bool = False,
+            sorted_result: bool = False,
     ):
         if parser_result:
-            self._print_table(
-                title="ParserResult",
-                columns=[
-                    {"header": "idx", "no_wrap": True},
-                    {"header": "result", "overflow": "fold", "key": "result"},
-                ],
-                data=self.parser_result,
-            )
+            if profile == "local":
+                self._print_table(
+                    title="ParserResult",
+                    columns=[
+                        {"header": "idx", "no_wrap": True},
+                        {
+                            "header": "result",
+                            "overflow": "fold",
+                            "key": "result",
+                            "max_width": 80,
+                        },
+                    ],
+                    data=self.parser_result,
+                )
+            else:
+                console_print(
+                    ConsoleDataType.DICT,
+                    self.parser_result,
+                    create_logger("ParserResult"),
+                )
 
         if crawling_result:
-            self._print_table(
-                title="CrawlingResult",
-                columns=[
-                    {"header": "idx", "no_wrap": True},
-                    {"header": "url", "overflow": "fold", "key": "url"},
-                    {
-                        "header": "title",
-                        "style": "magenta",
-                        "overflow": "fold",
-                        "key": "title",
-                    },
-                ],
-                data=self.crawling_result,
-            )
+            if profile == "local":
+                self._print_table(
+                    title="CrawlingResult",
+                    columns=[
+                        {"header": "idx", "no_wrap": True},
+                        {
+                            "header": "url",
+                            "overflow": "fold",
+                            "key": "url",
+                            "max_width": 80,
+                        },
+                        {
+                            "header": "title",
+                            "style": "magenta",
+                            "overflow": "fold",
+                            "key": "title",
+                            "max_width": 80,
+                        },
+                    ],
+                    data=self.crawling_result,
+                )
+            else:
+                dict_result = {
+                    site: [item.model_dump() for item in items]
+                    for site, items in self.crawling_result.items()
+                }
+                console_print(
+                    ConsoleDataType.DICT,
+                    dict_result,
+                    create_logger("CrawlingResult"),
+                )
 
         if filtering_result:
-            self._print_table(
-                title="FilteringResult",
-                columns=[
-                    {"header": "idx", "no_wrap": True},
-                    {"header": "url", "overflow": "fold", "key": "url"},
-                    {
-                        "header": "title",
-                        "style": "magenta",
-                        "overflow": "fold",
-                        "key": "title",
-                    },
-                ],
-                data=self.filtering_result,
-            )
+            if profile == "local":
+                self._print_table(
+                    title="FilteringResult",
+                    columns=[
+                        {"header": "idx", "no_wrap": True},
+                        {
+                            "header": "url",
+                            "overflow": "fold",
+                            "key": "url",
+                            "max_width": 80,
+                        },
+                        {
+                            "header": "title",
+                            "style": "magenta",
+                            "overflow": "fold",
+                            "key": "title",
+                            "max_width": 80,
+                        },
+                    ],
+                    data=self.filtering_result,
+                )
+            else:
+                dict_result = {
+                    site: [item.model_dump() for item in items]
+                    for site, items in self.filtering_result.items()
+                }
+                console_print(
+                    ConsoleDataType.DICT,
+                    dict_result,
+                    create_logger("FilteringResult"),
+                )
 
         if sorted_result:
-            self._print_table(
-                title="SortedResult",
-                columns=[
-                    {"header": "idx", "no_wrap": True},
-                    {"header": "url", "overflow": "fold", "key": "url"},
-                    {
-                        "header": "title",
-                        "style": "magenta",
-                        "overflow": "fold",
-                        "key": "title",
-                    },
-                    {
-                        "header": "reason",
-                        "style": "cyan",
-                        "overflow": "fold",
-                        "key": "reason",
-                    },
-                ],
-                data=self.sorted_result,
-            )
+            if profile == "local":
+                self._print_table(
+                    title="SortedResult",
+                    columns=[
+                        {"header": "idx", "no_wrap": True},
+                        {
+                            "header": "url",
+                            "overflow": "fold",
+                            "key": "url",
+                            "max_width": 40,
+                        },
+                        {
+                            "header": "title",
+                            "style": "magenta",
+                            "overflow": "fold",
+                            "key": "title",
+                            "max_width": 40,
+                        },
+                        {
+                            "header": "reason",
+                            "style": "cyan",
+                            "overflow": "fold",
+                            "key": "reason",
+                            "max_width": 40,
+                        },
+                    ],
+                    data=self.sorted_result,
+                )
+            else:
+                dict_result = {
+                    site: [item.model_dump() for item in items]
+                    for site, items in self.sorted_result.items()
+                }
+                console_print(
+                    ConsoleDataType.DICT,
+                    dict_result,
+                    create_logger("SortedResult"),
+                )
 
 
 class State(BaseModel):

--- a/news-scraper-agent/loader/connect.py
+++ b/news-scraper-agent/loader/connect.py
@@ -1,9 +1,11 @@
 from mongoengine import connect
 
 from config.env_config import env
-from config.log import default_logger
+from config.log import NewsScraperAgentLogger
 from models.message import Message
 from models.site import Site
+
+logger = NewsScraperAgentLogger()
 
 
 def connect_db():
@@ -15,16 +17,16 @@ def connect_db():
         else:
             connect(host=env.MONGO_DB_LOCAL_URI)
 
-        default_logger.info("MongoDB Connected ...")
+        logger.info("MongoDB Connected ...")
 
         # 컬렉션 생성 확인
         Site.ensure_indexes()
-        default_logger.info("Site Collection is ready!")
+        logger.info("Site Collection is ready!")
         Message.ensure_indexes()
-        default_logger.info("Message Collection is ready!")
+        logger.info("Message Collection is ready!")
 
     except Exception as err:
-        default_logger.error(f"MongoDB connect error: {err}")
+        logger.error(f"MongoDB connect error: {err}")
         exit(1)
 
 

--- a/news-scraper-agent/service/message_service.py
+++ b/news-scraper-agent/service/message_service.py
@@ -1,4 +1,3 @@
-from config.log import default_logger
 from models.message import Message
 from models.message import MessageDto, MessageContentDto
 
@@ -22,5 +21,4 @@ def get_messages(target_titles: list[str]) -> list[MessageDto]:
         )
         for message in messages_document_list
     ]
-    default_logger.info(f"messages: {messages}")
     return messages

--- a/news-scraper-agent/template.yaml
+++ b/news-scraper-agent/template.yaml
@@ -24,6 +24,7 @@ Resources:
           Type: ScheduleV2
           Properties:
             ScheduleExpression: 'cron(0 10 ? * 2-6 * )'
+            ScheduleExpressionTimezone: Asia/Seoul
             Name: news-scraper-agent
             Description: news-scraper-agent daily scheduler
     Metadata:

--- a/news-scraper-agent/utils/graph_image_utils.py
+++ b/news-scraper-agent/utils/graph_image_utils.py
@@ -1,6 +1,8 @@
 from langgraph.graph import StateGraph
 
-from config.log import default_logger
+from config.log import NewsScraperAgentLogger
+
+logger = NewsScraperAgentLogger()
 
 
 def get_graph_image(graph: StateGraph):
@@ -11,4 +13,4 @@ def get_graph_image(graph: StateGraph):
     with open("graph.png", "wb") as f:
         f.write(png_image)
 
-    default_logger.info("Image saved as graph.png")
+    logger.info("Image saved as graph.png")

--- a/template.yaml
+++ b/template.yaml
@@ -24,6 +24,7 @@ Resources:
           Type: ScheduleV2
           Properties:
             ScheduleExpression: 'cron(0 10 ? * 2-6 * )'
+            ScheduleExpressionTimezone: Asia/Seoul
             Name: news-scraper-agent
             Description: news-scraper-agent daily scheduler
       Policies:


### PR DESCRIPTION
Close #83 

## 변경 사항
- 최상위 template.yaml, news-scraper-agent 의 tamplate.yaml에 스케줄링 타임존 추가
   - 제가 추가한 줄 알았는데 반영이 안되어 있더라구요 .. (아마도 커밋만 해두고 push를 안한 것 같아 추가했습니다)
-  기존 로깅 모듈에 rich 통합하여 표시하도록 코드 수정 `log.py`
   - 고민을 좀 하다가 리서치를 해보니 rich가 이쁘다 보니 RichHandler를 logging Handler에 연결해서 쓰는 경우가 좀 있더라구요.
   - 기왕 라이브러리를 쓰기로 한 거 더 열심히 활용해보자는 느낌으로 핸들러를 RichHandler로 변경하여 콘솔 색상과 서식을 rich 것을 이용하도록 하였습니다.
       ![Pasted Graphic 4](https://github.com/user-attachments/assets/f4400f71-c02b-4685-9f77-2fcebbb96076)
   -  `console_print()` 함수는 기존에 console.print() 로 보여주던 부분을 함수로 변경한 것입니다.
      - richHandler로 변경하였기 때문에 logger.info() 이런 식으로 사용할 수 있습니다.
         -  `to_console_text()`함수는 logger에서 rich의 테이블이나 json 등의 형태를 표시해주기 위한 함수입니다. console.capture()라는 친구를 이용해서 rich의 콘솔 출력 내용을 캡쳐해서 문자열로 반환해주고 그 값을 return 합니다. [참고한 문서](https://github.com/Textualize/rich/discussions/1799)
- `state.print_state()`에 대하여... 
   - 여기에서 프린트를 찍기 위한 rich table 을 만들어주는게 맞나.. ? 라는 생각이 들었는데 사실 여기 말고는 더 좋은 곳도 없어 보이긴 합니다 .. ㅠㅠ 어떻게 생각하시나요? util 함수로 만들까요 ?!
   - 우선 `env.PROFILE`에 따라 로깅해줄 데이터 형태가 다른데(local은 rich.Table, 그 외는 dict) 이걸 log.py 에서 해주는 건 아닌 것 같고, 넘겨 줄 때 관련 타입으로 넘겨줘야 한다고 생각되어서 현재는 print_state()에 매개변수로 현재 PROFILE을 받아 if-else로 분기처리 해주었습니다. **더 좋은 방법이 있을까요 ...?**

## To reviewer
### 표시 되는 형태의 일부만 보여드리자면 ... 
dev, prod 일 때
![image](https://github.com/user-attachments/assets/904aae69-533b-4e43-ae7f-47f442d0673f)

local 일 때
![image](https://github.com/user-attachments/assets/4486c862-c9ab-4c84-a2d2-9c8844e0d2c9)
![image](https://github.com/user-attachments/assets/6f3251c4-9d8b-48e0-aa9c-efc130481cf5)
- sorted_result의 경우 행이 한 개 더 추가되는데 logger 에서 표시하도록 변경했다 보니 기존보다 사용하는 witdth가 더 작아져서 crawling_result, filtering_result 와 다르게 max_width 를 주었습니다.

sam local invoke 로 실행할 때
![image](https://github.com/user-attachments/assets/fd27ce37-31dc-4ccf-ade4-cd47d871c06f)
- 한 collapse? 에 결과 json 이 들어가는 형태라서 cloudwatch 에서는 그 collapse 열면 결과가 촤라락 나올 것으로 예상됩니다.