### PR TITLE
람다 자동재시작 횟수 1로 조정

### DIFF
--- a/news-scraper-agent/template.yaml
+++ b/news-scraper-agent/template.yaml
@@ -11,7 +11,7 @@ Resources:
     Properties:
       FunctionName: news-scraper-agent
       ImageUri: 339712918956.dkr.ecr.ap-northeast-2.amazonaws.com/ai-news-agent/news-scraper-agent
-      Timeout: 300 # 300초 (5분)
+      Timeout: 600 # 600초 (10분)
       EventInvokeConfig:
         MaximumRetryAttempts: 1
         MaximumEventAgeInSeconds: 21600 # 6시간

--- a/news-scraper-agent/template.yaml
+++ b/news-scraper-agent/template.yaml
@@ -12,6 +12,9 @@ Resources:
       FunctionName: news-scraper-agent
       ImageUri: 339712918956.dkr.ecr.ap-northeast-2.amazonaws.com/ai-news-agent/news-scraper-agent
       Timeout: 300 # 300초 (5분)
+      EventInvokeConfig:
+        MaximumRetryAttempts: 1
+        MaximumEventAgeInSeconds: 21600 # 6시간
       MemorySize: 512
       PackageType: Image
       Architectures:

--- a/scraper-lambda/template.yaml
+++ b/scraper-lambda/template.yaml
@@ -11,7 +11,7 @@ Resources:
     Properties:
       FunctionName: scraper-lambda
       ImageUri: 339712918956.dkr.ecr.ap-northeast-2.amazonaws.com/ai-news-agent/scraper-lambda
-      Timeout: 200 # 200초
+      Timeout: 300 # 300초
       MemorySize: 512
       PackageType: Image
       Architectures:

--- a/template.yaml
+++ b/template.yaml
@@ -12,6 +12,9 @@ Resources:
       FunctionName: news-scraper-agent
       ImageUri: 339712918956.dkr.ecr.ap-northeast-2.amazonaws.com/ai-news-agent/news-scraper-agent
       Timeout: 300 # 300초 (5분)
+      EventInvokeConfig:
+        MaximumRetryAttempts: 1
+        MaximumEventAgeInSeconds: 21600 # 6시간
       MemorySize: 512
       PackageType: Image
       Architectures:

--- a/template.yaml
+++ b/template.yaml
@@ -11,7 +11,7 @@ Resources:
     Properties:
       FunctionName: news-scraper-agent
       ImageUri: 339712918956.dkr.ecr.ap-northeast-2.amazonaws.com/ai-news-agent/news-scraper-agent
-      Timeout: 300 # 300초 (5분)
+      Timeout: 600 # 600초 (10분)
       EventInvokeConfig:
         MaximumRetryAttempts: 1
         MaximumEventAgeInSeconds: 21600 # 6시간
@@ -47,7 +47,7 @@ Resources:
     Properties:
       FunctionName: scraper-lambda
       ImageUri: 339712918956.dkr.ecr.ap-northeast-2.amazonaws.com/ai-news-agent/scraper-lambda
-      Timeout: 200 # 200초
+      Timeout: 300 # 300초
       MemorySize: 512
       PackageType: Image
       Architectures:


### PR DESCRIPTION
Close #90 

MaximumEventAgeInSecond는 람다 기본값이 6시간이라 유지했고
RetryAttempts는 2였는데 1로 줄였습니다~

++ 테스트하면서 배포해서 이미 1로 배포는되어있는 상태입니다