### PR TITLE
[codex] Refactor Kakaowork message builder

### DIFF
--- a/news-scraper-agent/external/kakaowork/message_builder.py
+++ b/news-scraper-agent/external/kakaowork/message_builder.py
@@ -1,8 +1,9 @@
 from zoneinfo import ZoneInfo
 
 from datetime import datetime
+from typing import List
 
-from graph.state import CrawlingResult
+from graph.state import CrawlingResult, PageCrawlingData
 from external.kakaowork.message_blocks import (
     KakaoworkMessageRequest,
     HeaderBlock,
@@ -17,50 +18,57 @@ from external.kakaowork.message_blocks import (
 
 
 class KakaoworkMessageBuilder:
-    def __init__(self):
-        # none
-        pass
+    """Utility class for creating Kakaowork message payloads."""
+
+    @staticmethod
+    def _build_site_blocks(
+        site_name: str, site_data: List[PageCrawlingData]
+    ) -> List[HeaderBlock | TextBlock | DividerBlock | SectionBlock | ButtonBlock]:
+        """Return blocks representing a single site's news list."""
+
+        blocks: list = [
+            TextBlock(
+                text=site_name,
+                inlines=[InnerTextBlock(text=site_name, bold=True)],
+            )
+        ]
+
+        inlines = [
+            InnerTextUrlBlock(
+                text=f"{item.title}\n" if idx == len(site_data) - 1 else f"{item.title}\n\n",
+                url=item.url,
+            )
+            for idx, item in enumerate(site_data)
+            if item.title and item.url
+        ]
+
+        if inlines:
+            blocks.append(SectionBlock(content=TextBlock(inlines=inlines)))
+            blocks.append(DividerBlock())
+
+        return blocks
 
     @staticmethod
     def build(unique_site_news_dict: CrawlingResult) -> KakaoworkMessageRequest:
-        has_empty_list = all(
-            len(page_crawling_data_list) == 0
-            for site_name, page_crawling_data_list in unique_site_news_dict.items()
-        )
+        """Create a message body from a dictionary of site news."""
+
+        has_news = any(len(data) > 0 for data in unique_site_news_dict.values())
 
         today = datetime.now(tz=ZoneInfo("Asia/Seoul")).strftime("%Y-%m-%d")
 
         blocks = [HeaderBlock(text=f"📢 {today} AI 소식", style="blue")]
-        if has_empty_list:
+        if not has_news:
             blocks.append(
                 TextBlock(
-                    inlines=[
-                        InnerTextBlock(text="오늘은 소식이 없어요! 😅", bold=False)
-                    ]
+                    inlines=[InnerTextBlock(text="오늘은 소식이 없어요! 😅", bold=False)]
                 )
             )
         else:
             for site_name, site_data in unique_site_news_dict.items():
-                if len(site_data) == 0:
+                if not site_data:
                     continue
 
-                blocks.append(
-                    TextBlock(
-                        text=site_name,
-                        inlines=[InnerTextBlock(text=site_name, bold=True)],
-                    )
-                )
-                inlines = []
-                for idx, item in enumerate(site_data):
-                    if item.title and item.url:
-                        is_last_item = idx == len(site_data) - 1
-                        # 가독성을 위해 각 뉴스별 마지막 기사는 구분선(\n) 한 개 더 추가
-                        title = (
-                            f"{item.title}\n" if is_last_item else f"{item.title}\n\n"
-                        )
-                        inlines.append(InnerTextUrlBlock(text=title, url=item.url))
-                blocks.append(SectionBlock(content=TextBlock(inlines=inlines)))
-                blocks.append(DividerBlock())
+                blocks.extend(KakaoworkMessageBuilder._build_site_blocks(site_name, site_data))
 
         blocks.append(
             ButtonBlock(


### PR DESCRIPTION
## Summary
- refactor KakaoworkMessageBuilder
  - extract helper method for site blocks
  - add documentation and simplify logic

## Testing
- `python -m py_compile news-scraper-agent/external/kakaowork/message_builder.py`
- `PYTHONPATH=scraper-lambda/src python -m unittest discover scraper-lambda/tests` *(fails: ModuleNotFoundError)*
- `PYTHONPATH=news-scraper-agent python -m unittest discover news-scraper-agent/tests`