### PR TITLE
[jules] Refactor: Optimize agent and LLM instantiation

### DIFF
--- a/news-scraper-agent/agents/crawling_agent.py
+++ b/news-scraper-agent/agents/crawling_agent.py
@@ -18,32 +18,31 @@ class CrawlingAgent:
         or DefaultPromptTemplate.CRAWLING_AGENT_PROMPT_KO
     )
 
-    def __init__(self, llm: BaseLanguageModel, site: SiteDto, prompt: str = None):
+    def __init__(self, llm: BaseLanguageModel, prompt: str = None):
         self.logger = NewsScraperAgentLogger(self.__class__.__name__)
         self.prompt = PromptTemplate.from_template(
             prompt if prompt else self.crawling_prompt
         )
-        self.site = site
         self.llm = llm
 
     @log_time_agent_method
-    def __call__(self, state: SiteState) -> SiteState:
+    def __call__(self, site: SiteDto, state: SiteState) -> SiteState:
         if (
-            state.parser_result[self.site.name] is None
-            or len(state.parser_result[self.site.name]) == 0
+            state.parser_result[site.name] is None
+            or len(state.parser_result[site.name]) == 0
         ):
-            self.logger.warning(f"No data to crawl for {self.site.name}")
-            state.crawling_result[self.site.name] = []
+            self.logger.warning(f"No data to crawl for {site.name}")
+            state.crawling_result[site.name] = []
             return state
 
         try:
             compressed_parser_result = list(
-                map(self.__strip_attributes, state.parser_result[self.site.name])
+                map(self.__strip_attributes, state.parser_result[site.name])
             )
 
             formatted_prompt = self.crawling_prompt.format(
-                site_name=self.site.name,
-                site_url=self.site.url,
+                site_name=site.name,
+                site_url=site.url,
                 parser_result=compressed_parser_result,
             )
 
@@ -52,10 +51,10 @@ class CrawlingAgent:
                 formatted_prompt
             )
 
-            state.crawling_result[self.site.name] = response.items
+            state.crawling_result[site.name] = response.items
         except Exception as e:
-            self.logger.error(f"Error occurred while crawling {self.site.name}: {e}")
-            state.crawling_result[self.site.name] = []
+            self.logger.error(f"Error occurred while crawling {site.name}: {e}")
+            state.crawling_result[site.name] = []
 
         state.print_state(crawling_result=True)
         return state

--- a/news-scraper-agent/agents/filtering_agent.py
+++ b/news-scraper-agent/agents/filtering_agent.py
@@ -24,22 +24,21 @@ class FilteringAgent:
         or DefaultPromptTemplate.FILTERING_AGENT_PROMPT_KO
     )
 
-    def __init__(self, llm: BaseLanguageModel, site: SiteDto, prompt: str = None):
+    def __init__(self, llm: BaseLanguageModel, prompt: str = None):
         self.logger = NewsScraperAgentLogger(self.__class__.__name__)
-        self.site = site
         self.prompt = PromptTemplate.from_template(
             prompt if prompt else self.filtering_prompt
         )
         self.llm = llm
 
     @log_time_agent_method
-    def __call__(self, state: SiteState) -> SiteState:
+    def __call__(self, site: SiteDto, state: SiteState) -> SiteState:
         if (
-            not state.crawling_result[self.site.name]
-            or len(state.crawling_result[self.site.name]) == 0
+            not state.crawling_result[site.name]
+            or len(state.crawling_result[site.name]) == 0
         ):
-            self.logger.warning(f"No data to filter for {self.site.name}")
-            state.filtering_result[self.site.name] = []
+            self.logger.warning(f"No data to filter for {site.name}")
+            state.filtering_result[site.name] = []
             return state
 
         try:
@@ -48,7 +47,7 @@ class FilteringAgent:
             # 모델 응답으로 원본 데이터를 찾기위한 딕셔너리
             crawling_results_map: dict[int, PageCrawlingData] = {}
 
-            for idx, item in enumerate(state.crawling_result[self.site.name], start=1):
+            for idx, item in enumerate(state.crawling_result[site.name], start=1):
                 data_id = idx
                 crawling_results_with_id.append(
                     FilterRequestItem(id=data_id, title=item.title)
@@ -71,10 +70,10 @@ class FilteringAgent:
             filtering_result = [
                 crawling_results_map[item_id] for item_id in response.items
             ]
-            state.filtering_result[self.site.name] = filtering_result
+            state.filtering_result[site.name] = filtering_result
         except Exception as e:
-            self.logger.error(f"Error occurred while filtering {self.site.name}: {e}")
-            state.filtering_result[self.site.name] = []
+            self.logger.error(f"Error occurred while filtering {site.name}: {e}")
+            state.filtering_result[site.name] = []
 
         state.print_state(filtering_result=True)
         return state

--- a/news-scraper-agent/agents/html_parser_agent.py
+++ b/news-scraper-agent/agents/html_parser_agent.py
@@ -17,38 +17,37 @@ class ParsingLambdaRequestBody(TypedDict):
 
 
 class HtmlParserAgent:
-    def __init__(self, site: SiteDto):
+    def __init__(self):
         self.logger = NewsScraperAgentLogger(self.__class__.__name__)
-        self.site = site
         self.lambda_invoker = LambdaInvoker()
         self.function_name = f"scraper-lambda-{env.PROFILE}"
         if env.PROFILE == "local":
             self.function_name = "scraper-lambda-dev"
 
     @log_time_agent_method
-    def __call__(self, state: SiteState = None) -> SiteState:
-        request_body = json.dumps(self.__create_payload())
+    def __call__(self, site: SiteDto, state: SiteState = None) -> SiteState:
+        request_body = json.dumps(self.__create_payload(site))
         try:
             response = self.lambda_invoker.invoke(
                 FunctionName=self.function_name,
                 InvocationType="RequestResponse",
                 Payload=request_body,
-                logging_name=f"scraper-lambda for {self.site.name}",
+                logging_name=f"scraper-lambda for {site.name}",
             )
 
             response_data: list[str] = response["result"]
 
-            if self.site.name == "데보션":
-                response_data = self.__parse_devocean_detail(response_data)
+            if site.name == "데보션":
+                response_data = self.__parse_devocean_detail(site, response_data)
 
-            state.parser_result[self.site.name] = response_data
+            state.parser_result[site.name] = response_data
         except Exception as e:
-            self.logger.error(f"Error occurred while parsing {self.site.name}: {e}")
-            state.parser_result[self.site.name] = []
+            self.logger.error(f"Error occurred while parsing {site.name}: {e}")
+            state.parser_result[site.name] = []
         return state
 
-    def __create_payload(self) -> ParsingLambdaRequestBody:
-        match url := self.site.url:
+    def __create_payload(self, site: SiteDto) -> ParsingLambdaRequestBody:
+        match url := site.url:
             case url if "news.hada.io" in url:
                 return {
                     "url": url,
@@ -71,13 +70,13 @@ class HtmlParserAgent:
                 self.logger.error(f"정의되지 않은 페이지 (url: ${url})")
                 raise ValueError("정의되지 않은 페이지 입니다.")
 
-    def __parse_devocean_detail(self, result: list[str]):
+    def __parse_devocean_detail(self, site: SiteDto, result: list[str]):
         title_html = result[0]
         pattern = r"onclick=\"goDetail\(this,'(\d+)',event\)"
 
         matched = re.search(pattern, title_html)
         if not matched:
-            raise ValueError(f"{self.site.name} 파싱 실패")
+            raise ValueError(f"{site.name} 파싱 실패")
 
         detail_page = (
             f"https://devocean.sk.com/blog/techBoardDetail.do?ID={matched.group(1)}"

--- a/news-scraper-agent/agents/sorting_agent.py
+++ b/news-scraper-agent/agents/sorting_agent.py
@@ -31,22 +31,21 @@ class SortingAgent:
         or DefaultPromptTemplate.SORTING_AGENT_PROMPT_KO
     )
 
-    def __init__(self, llm: BaseLanguageModel, site: SiteDto, prompt: str = None):
+    def __init__(self, llm: BaseLanguageModel, prompt: str = None):
         self.logger = NewsScraperAgentLogger(self.__class__.__name__)
-        self.site = site
         self.prompt = PromptTemplate.from_template(
             prompt if prompt else self.sorting_prompt
         )
         self.llm = llm
 
     @log_time_agent_method
-    def __call__(self, state: SiteState) -> SiteState:
+    def __call__(self, site: SiteDto, state: SiteState) -> SiteState:
         if (
-            not state.filtering_result[self.site.name]
-            or len(state.filtering_result[self.site.name]) == 0
+            not state.filtering_result[site.name]
+            or len(state.filtering_result[site.name]) == 0
         ):
-            self.logger.warning(f"No data to sort for {self.site.name}")
-            state.sorted_result[self.site.name] = []
+            self.logger.warning(f"No data to sort for {site.name}")
+            state.sorted_result[site.name] = []
             return state
 
         try:
@@ -55,7 +54,7 @@ class SortingAgent:
             # 모델 응답으로 원본 데이터를 찾기위한 딕셔너리
             filtering_results_map: dict[int, PageCrawlingData] = {}
 
-            for idx, item in enumerate(state.filtering_result[self.site.name], start=1):
+            for idx, item in enumerate(state.filtering_result[site.name], start=1):
                 data_id = idx
                 filtering_results_with_id.append(
                     SortRequestItem(id=data_id, title=item.title)
@@ -74,14 +73,14 @@ class SortingAgent:
                 result_item.reason = item.reason
                 sorted_result.append(result_item)
 
-            state.sorted_result[self.site.name] = sorted_result
+            state.sorted_result[site.name] = sorted_result
         except Exception as e:
-            self.logger.error(f"Error occurred while sorting {self.site.name}: {e}")
-            self.logger.warning(f"Skip sorting {self.site.name}")
+            self.logger.error(f"Error occurred while sorting {site.name}: {e}")
+            self.logger.warning(f"Skip sorting {site.name}")
 
-            state.sorted_result[self.site.name] = [
+            state.sorted_result[site.name] = [
                 PageCrawlingData(url=item.url, title=item.title, reason=item.reason)
-                for item in state.filtering_result[self.site.name]
+                for item in state.filtering_result[site.name]
             ]
 
         state.print_state(sorted_result=True)

--- a/news-scraper-agent/graph/build_graph.py
+++ b/news-scraper-agent/graph/build_graph.py
@@ -20,32 +20,55 @@ fake_responses = [
     "[]",
 ]
 # llm = FakeListLLM(responses=fake_responses)  # FIXME 테스트 시 사용
+llm = ChatOpenAI(model="gpt-4o")
 
 
-def create_crawl_filter_sequence(site: SiteDto) -> Callable[[State], SiteState]:
-    html_parser_agent = HtmlParserAgent(site=site)
-    crawling_agent = CrawlingAgent(ChatOpenAI(model="gpt-4o"), site=site)
-    filtering_agent = FilteringAgent(ChatOpenAI(model="gpt-4o"), site=site)
-    sorting_agent = SortingAgent(ChatOpenAI(model="gpt-4o"), site=site)
-
+def create_crawl_filter_sequence(
+    site: SiteDto,
+    html_parser_agent_instance: HtmlParserAgent,
+    crawling_agent_instance: CrawlingAgent,
+    filtering_agent_instance: FilteringAgent,
+    sorting_agent_instance: SortingAgent,
+) -> Callable[[State], SiteState]:
     def process_site(state: State) -> SiteState:
         initial_site_state = SiteState(
             crawling_result={}, filtering_result={}, parser_result={}, sorted_result={}
         )
-        state = html_parser_agent(initial_site_state)
-        state = crawling_agent(state)
-        state = filtering_agent(state)
-        state = sorting_agent(state)
-        return state
+        # Pass site to the __call__ method of each agent
+        current_site_state = html_parser_agent_instance(
+            site=site, state=initial_site_state
+        )
+        current_site_state = crawling_agent_instance(
+            site=site, state=current_site_state
+        )
+        current_site_state = filtering_agent_instance(
+            site=site, state=current_site_state
+        )
+        current_site_state = sorting_agent_instance(
+            site=site, state=current_site_state
+        )
+        return current_site_state
 
     return process_site
 
 
-def parallel_crawl_filter(state: State) -> State:
+def parallel_crawl_filter(
+    state: State,
+    html_parser_agent_instance: HtmlParserAgent,
+    crawling_agent_instance: CrawlingAgent,
+    filtering_agent_instance: FilteringAgent,
+    sorting_agent_instance: SortingAgent,
+) -> State:
     sites = state.sites
 
     parallel_sequences = {
-        f"{site.name}": create_crawl_filter_sequence(site)
+        f"{site.name}": create_crawl_filter_sequence(
+            site,
+            html_parser_agent_instance,
+            crawling_agent_instance,
+            filtering_agent_instance,
+            sorting_agent_instance,
+        )
         for i, site in enumerate(sites)
     }
 
@@ -66,12 +89,26 @@ def parallel_crawl_filter(state: State) -> State:
 
 
 def build_graph(initial_state: State):
+    html_parser_agent = HtmlParserAgent()
+    crawling_agent = CrawlingAgent(llm=llm)
+    filtering_agent = FilteringAgent(llm=llm)
+    sorting_agent = SortingAgent(llm=llm)
+
     builder = StateGraph(State)
 
     # init node
     builder.add_node("start", lambda x: initial_state)
     builder.add_node("get_sites", get_sites)
-    builder.add_node("parallel_crawl_filter", parallel_crawl_filter)
+    builder.add_node(
+        "parallel_crawl_filter",
+        lambda state: parallel_crawl_filter(
+            state,
+            html_parser_agent,
+            crawling_agent,
+            filtering_agent,
+            sorting_agent,
+        ),
+    )
     builder.add_node("send_message", MessageAgent())
 
     # connect edge


### PR DESCRIPTION
This refactoring centralizes the creation of LLM instances and news processing agents (`HtmlParserAgent`, `CrawlingAgent`, `FilteringAgent`, `SortingAgent`).

Key changes:
- Agents are now instantiated only once in `news-scraper-agent/graph/build_graph.py` and reused for processing multiple sites.
- The `site` object, previously passed to agent constructors, is now passed to their `__call__` methods.
- The `ChatOpenAI` LLM is instantiated once and shared among agents that require it.

These changes reduce redundant object creation, leading to improved efficiency and resource utilization within the news scraping graph.

The test file `news-scraper-agent/tests/crawling_agent_test.py` was also updated to align with the new agent method signatures. Existing tests require a valid OpenAI API key to pass fully.